### PR TITLE
Update send_form.php

### DIFF
--- a/send_form.php
+++ b/send_form.php
@@ -52,7 +52,7 @@ if(isset($_POST['email'])) {
   }
  
  
-$header = 'From: ' . $email_from . "\r\n" . 'X-Mailer: PHP/' . phpversion();
+$header = 'Content-Type: text/html; charset=UTF-8' . 'From: ' . $email_from . "\r\n" . 'X-Mailer: PHP/' . phpversion();
  
 @mail($email_to, $subject, $message, $header);  
  


### PR DESCRIPTION
Adding 'Content-Type: text/html; charset=UTF-8' in $header allows for correct display of non ASCII characters in message text. It works for me with Iceweasel, Enigmail, Debian Wheezy 64 bit. I don't know enough about PHP & email to be sure that it doesn't break anything else. Please check! :)
